### PR TITLE
Change 'data' field representation to a string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ All below messages with `data` follow the below structure:
 The hash used for `signature` follows the SHA-256 algorithm.
 base64 encoding follows RFC 4648.
 
-Data being represented as a string is to ensure consistency when verifying message signatures. Throughout this documented, it will be represented as a regular JSON object.
+Data being represented as a string is to ensure consistency when verifying message signatures. Throughout this document, it will be represented as a regular JSON object.
 
 
 #### Hello

--- a/readme.md
+++ b/readme.md
@@ -272,20 +272,15 @@ Asymmetric encryption and decryption is performed with RSA.
 - Padding scheme: OAEP with SHA-256 digest/hash function
 - Public keys are exported in PEM encoding with SPKI format.
 
+### Message Signing
 Signing and verification also uses RSA. It shares the same keys as encryption/decryption.
 - Padding scheme: PSS with SHA-256 digest/hash function
 - Salt length: 32 bytes
 
+### Symmetric Encryption
 Symmetric encryption is performed with AES in GCM mode.
 - Initialisation vector (IV) = 16 bytes (Must be randomly generated)
 - Additional/associated data = not used (empty).
 - Key length: 16 bytes (128 bits)
 - Authentication tag: 16 bytes (128 bits). The authentication tag takes up the final 128 bits of the ciphertext.
-
-### Order to apply different layers of encryption
-- message is created
-- create a signature by applying the signature scheme RSA-PSS 
-- encrypt the message using the symmetric encryption specified above
-- encrypt the symmetric key used to encrypt the message with the public asymmetric encryption key of the intended recipient
-- format these to be sent as shown in protocol defined messages
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# OLAF/Neighbourhood protocol v1.1.3
+# OLAF/Neighbourhood protocol v1.2
 By James, Jack, Tom, Mia, Valen, Isabelle, Katie & Cubie
 
 ## Definitions
@@ -42,14 +42,16 @@ All below messages with `data` follow the below structure:
 ```JSON
 {
     "type": "signed_data",
-    "data": {  },
+    "data": "<JSON Object, encoded as a string>",
     "counter": 12345,
     "signature": "<Base64 encoded (signature of (data JSON concatenated with counter))>"
 }
 ```
 `counter` is a monotonically increasing integer. All handlers of a message should track the last counter value sent by a client and reject it if the current value is not greater than the last value. This defeats replay attacks.
-The hash used for `signature` follows the SHA-256 algorithm. 
+The hash used for `signature` follows the SHA-256 algorithm.
 base64 encoding follows RFC 4648.
+
+Data being represented as a string is to ensure consistency when verifying message signatures. Throughout this documented, it will be represented as a regular JSON object.
 
 
 #### Hello


### PR DESCRIPTION
Changes made:
- Encode all 'data' fields as JSON strings, not JSON objects
- Remove 'encryption order' section

We need to ensure when verifying a message signature, that we are verifying the exact same string as was signed. Currently it is unspecified exactly how this will occur, especially as messages are meant to be signed before being encrypted (so we can't even rely on using the raw JSON text, as the sender encoded it).

The simplest way to ensure consistency is to send the exact string being signed. This should reduce the overhead of modifying existing implementations.

The order of encryption section is now redundant and has been removed. We now sign after the message data is JSONified, and the other two encryption orderings don't affect each other.